### PR TITLE
content-lengthの値が圧縮後のサイズになるケースがあったので、圧縮前のサイズを取得するようにした

### DIFF
--- a/lib/file_downloader/service.rb
+++ b/lib/file_downloader/service.rb
@@ -31,10 +31,11 @@ module FileDownloader
     def fetch_content_length(http, uri)
       http.use_ssl = true if uri.port == 443
 
-      res = http.head(uri.request_uri)
+      # net-httpによるリクエスト時のデフォルトのAccept-Encoding は ["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"] だが、
+      # サーバによって圧縮後の Content-Length を返すケースがあるため、元のサイズを得る目的でHEADリクエストでは無圧縮とする
+      res = http.head(uri.request_uri, 'accept-encoding' => '')
       Status.check(res.code)
-      header = res.to_hash
-      header['content-length'][0]
+      res.content_length
     end
 
     def download_file(http, uri, content_length)


### PR DESCRIPTION
## このPRでやりたいこと

Content-Lengthの値を正しく取得できるようにしたい。

FileDownloader.download では、ファイルが最後までダウンロードできたか判定するために、ダウンロード前にHEADリクエストを行い、Content-Lengthの値でダウンロードするファイルのサイズを取得している。

HEADリクエストを行う際、 Accept-Encoding に圧縮形式を指定することで、相手先サーバによって Content-Length の値が圧縮後のサイズになる、あるいは Content-Length が返されない場合があることがわかった。

FileDownloaderでは、Content-Lengthの値とファイルシステムに書き込んだサイズを比較して最後までダウンロードできたか判定しているため、 Content-Length は圧縮前のファイルサイズで取得できることが望ましい。

## やったこと

FileDownloader::Service#fetch_content_length で HEAD リクエストを行う時に、リクエストヘッダを `'accept-encoding' => ''` でオーバーライドした。

- デフォルトの Accept-Encoding の値は "gzip;q=1.0,deflate;q=0.6,identity;q=0.3" であったため
  see: https://github.com/ruby/net-http/blob/042faf74e77d786ff60dff81555f6ec4f21e77a9/lib/net/http/request.rb#L31


