### PR TITLE
`OpenSSL::SSL::SSLContext` に `OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT`を設定する

### DIFF
--- a/lib/file_downloader/service.rb
+++ b/lib/file_downloader/service.rb
@@ -2,6 +2,10 @@ require 'file_downloader/status'
 require 'net/http'
 require 'logger'
 
+# OpenSSL 3.x の制約を回避するために `OpenSSL::SSL::SSLContext` に `OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT` を設定する。
+# OpenSSL 3.x では「レガシーな TLS 再ネゴシエーション」がデフォルトで無効化されているため、これを有効化することで古い TLS 設定のサーバーとも通信できるようにする。
+OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options] |= OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT
+
 module FileDownloader
   class NoResponseBodyError < StandardError; end
   class NotEofError < StandardError; end


### PR DESCRIPTION
## Why
Heroku スタックを v24 にアップグレードしたところ、OpenSSL のバージョンが 1.1 から 3系に上がった。OpenSSL 3.0では、一部のレガシーなTLS再ネゴシエーションがデフォルトで無効化されたため、HTTP の HEADリクエストで、`SSL_connect returned=1 errno=0 peeraddr=210.160.220.115:443 state=error: unsafe legacy renegotiation disabled` のエラーが出るようになった。

そこで、OpenSSL 3.0 の制約を回避するために `OpenSSL::SSL::SSLContext` に `OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT` を設定することで、古い TLS 設定のサーバーとも通信できるようにする。

本来であれば、今回エラー対象となったショップサーブのサーバーのTLS設定を変更してもらうのが良いが、いつ解消されるかわからないため、一時的な対応としてレガシーなTLS通信を許容する。

## How to review it
- CI が通っていること

## Merge condition
- @kano-e or @azmin8744 

## Note
- [XユーザーのM. Higashinoさん: 「とりあえずRubyのnet/http + OpenSSL 3でunsafe legacy renegotiation disabledを回避する方法。 * [Using OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION in Ruby's net/http](https://t.co/yn7VQZ7RpE)」 / X](https://x.com/61503891/status/1557691723886628865)
- [Using SSL_OP_LEGACY_SERVER_CONNECT in Ruby's net/http](https://gist.github.com/mh61503891/ba2e8eb588caa473d0565349eb755f9e)